### PR TITLE
Force Query Strings to be Case Sensitive

### DIFF
--- a/src/SqlStreamStore.HAL/CaseSensitiveQueryCollection.cs
+++ b/src/SqlStreamStore.HAL/CaseSensitiveQueryCollection.cs
@@ -1,0 +1,64 @@
+﻿namespace SqlStreamStore.HAL
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Http.Features;
+    using Microsoft.Extensions.Primitives;
+
+    internal class CaseSensitiveQueryFeature : IQueryFeature
+    {
+        private readonly IFeatureCollection _features;
+
+        public CaseSensitiveQueryFeature(IFeatureCollection features)
+        {
+            if(features == null)
+                throw new ArgumentNullException(nameof(features));
+            _features = features;
+        }
+
+        public IQueryCollection Query
+        {
+            get;
+            set;
+        }
+    }
+
+    internal class CaseSensitiveQueryCollection : IQueryCollection
+    {
+        private readonly QueryString _queryString;
+
+        private Dictionary<string, StringValues> _state;
+
+        public CaseSensitiveQueryCollection(QueryString queryString)
+        {
+            _queryString = queryString;
+        }
+
+        private Dictionary<string, StringValues> GetState()
+            => _state
+               ?? (_state = QueryStringHelper.ParseQueryString(_queryString));
+
+        public IEnumerator<KeyValuePair<string, StringValues>> GetEnumerator()
+            => GetState().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public bool ContainsKey(string key)
+            => GetState().ContainsKey(key);
+
+        public bool TryGetValue(string key, out StringValues value)
+            => GetState().TryGetValue(key, out value);
+
+        public int Count
+            => GetState().Count;
+
+        public ICollection<string> Keys
+            => GetState().Keys;
+
+        public StringValues this[string key]
+            => GetState()[key];
+    }
+}

--- a/src/SqlStreamStore.HAL/QueryCollectionExtensions.cs
+++ b/src/SqlStreamStore.HAL/QueryCollectionExtensions.cs
@@ -1,0 +1,23 @@
+namespace SqlStreamStore.HAL
+{
+    using System;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Primitives;
+
+    internal static class QueryCollectionExtensions
+    {
+        public static bool TryGetValueCaseInsensitive(this IQueryCollection query, char key, out StringValues values)
+        {
+            if(query == null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            return char.IsUpper(key)
+                ? query.TryGetValue(key.ToString(), out values)
+                  || query.TryGetValue(char.ToLower(key).ToString(), out values)
+                : query.TryGetValue(key.ToString(), out values)
+                  || query.TryGetValue(char.ToUpper(key).ToString(), out values);
+        }
+    }
+}

--- a/src/SqlStreamStore.HAL/QueryStringHelper.cs
+++ b/src/SqlStreamStore.HAL/QueryStringHelper.cs
@@ -1,0 +1,51 @@
+﻿namespace SqlStreamStore.HAL
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Primitives;
+
+    internal static class QueryStringHelper
+    {
+        private static readonly char[] s_delimiter = { '=' };
+        private static readonly QueryString s_almostEmpty = new QueryString("?");
+
+        public static Dictionary<string, StringValues> ParseQueryString(QueryString queryString)
+        {
+            var state = new Dictionary<string, StringValues>();
+
+            if(queryString == QueryString.Empty || queryString == s_almostEmpty)
+            {
+                return state;
+            }
+
+            var qs = queryString.Value;
+
+            if(qs[0] == '?')
+            {
+                qs = qs.Substring(1);
+            }
+
+            foreach(var pair in qs.Split('&'))
+            {
+                var parts = pair.Split(s_delimiter, 2);
+                var key = Uri.UnescapeDataString(parts[0].Replace('+', ' '));
+
+                state.TryGetValue(key, out var values);
+
+                if(parts.Length == 1)
+                {
+                    state[key] = values;
+                }
+                else
+                {
+                    var value = Uri.UnescapeDataString(parts[1].Replace('+', ' '));
+
+                    state[key] = StringValues.Concat(value, values);
+                }
+            }
+
+            return state;
+        }
+    }
+}


### PR DESCRIPTION
In order to maximise cache-hits on a reverse proxy e.g. CloudFront, we want to normalize all urls. However, aspnet core inexplicably treats query string keys as case-insensitive - ?d=b is the same as ?D=b.

Until aspnet/Home#3450 gets resolved this code will have to exist :(