### PR TITLE
Fix Inconsistencies When Creating Stream

### DIFF
--- a/src/SqlStreamStore.HAL.Tests/StreamAppendTests.cs
+++ b/src/SqlStreamStore.HAL.Tests/StreamAppendTests.cs
@@ -6,7 +6,6 @@
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Reflection;
     using System.Threading.Tasks;
     using Newtonsoft.Json.Linq;
     using Shouldly;
@@ -285,17 +284,12 @@
         {
             var random = new Random();
 
-            var minimum = (from fieldInfo in typeof(ExpectedVersion)
-                                  .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                              where fieldInfo.IsLiteral
-                                    && !fieldInfo.IsInitOnly
-                                    && fieldInfo.FieldType == typeof(int)
-                              select (int) fieldInfo.GetRawConstantValue()).Min() - 1;
+            var maximumBadExpectedVersion = Constants.Headers.MinimumExpectedVersion - 1;
 
-            yield return new object[] { minimum };
+            yield return new object[] { maximumBadExpectedVersion };
             for(var i = 0; i < 5; i++)
             {
-                yield return new object[] { random.Next(int.MinValue, minimum) };
+                yield return new object[] { random.Next(int.MinValue, maximumBadExpectedVersion) };
             }
         }
 

--- a/src/SqlStreamStore.HAL.Tests/StreamAppendTests.cs
+++ b/src/SqlStreamStore.HAL.Tests/StreamAppendTests.cs
@@ -24,7 +24,8 @@
 
         public static IEnumerable<object[]> AppendCases()
         {
-            var messageId = Guid.NewGuid();
+            var messageId1 = Guid.NewGuid();
+            var messageId2 = Guid.NewGuid();
 
             var jsonData = JObject.FromObject(new
             {
@@ -36,69 +37,83 @@
                 property = "metaValue"
             });
 
-            var bodies = new JToken[]
+            var bodies = new (JToken, Guid[])[]
             {
-                JObject.FromObject(new
+                (JObject.FromObject(new
                 {
-                    messageId,
+                    messageId = messageId1,
                     type = "type",
                     jsonData,
                     jsonMetadata
-                }),
-                JArray.FromObject(new[]
-                {
-                    new
+                }), new[] { messageId1 }),
+                (JArray.FromObject(new[]
                     {
-                        messageId,
-                        type = "type",
-                        jsonData,
-                        jsonMetadata
-                    }
-                })
+                        new
+                        {
+                            messageId = messageId1,
+                            type = "type",
+                            jsonData,
+                            jsonMetadata
+                        },
+                        new
+                        {
+                            messageId = messageId2,
+                            type = "type",
+                            jsonData,
+                            jsonMetadata
+                        }
+                    }),
+                    new[] { messageId1, messageId2 })
             };
 
-            foreach(var body in bodies)
+            var location = new Uri($"../{Constants.Streams.Stream}/{StreamId}", UriKind.Relative);
+
+            foreach(var (body, messageIds) in bodies)
             {
                 yield return new object[]
                 {
-                    body,
                     ExpectedVersion.Any,
-                    HttpStatusCode.Created,
-                    messageId,
+                    body,
+                    messageIds,
                     jsonData,
-                    jsonMetadata
+                    jsonMetadata,
+                    HttpStatusCode.OK,
+                    null
                 };
                 yield return new object[]
                 {
-                    body,
                     default(int?),
-                    HttpStatusCode.Created,
-                    messageId,
+                    body,
+                    messageIds,
                     jsonData,
-                    jsonMetadata
+                    jsonMetadata,
+                    HttpStatusCode.OK,
+                    null
                 };
                 yield return new object[]
                 {
-                    body,
                     ExpectedVersion.NoStream,
-                    HttpStatusCode.Created,
-                    messageId,
+                    body,
+                    messageIds,
                     jsonData,
-                    jsonMetadata
+                    jsonMetadata,
+                    HttpStatusCode.Created,
+                    location
                 };
             }
         }
 
         [Theory, MemberData(nameof(AppendCases))]
         public async Task expected_version(
-            JToken body,
             int? expectedVersion,
-            HttpStatusCode statusCode,
-            Guid messageId,
+            JToken body,
+            Guid[] messageIds,
             JObject jsonData,
-            JObject jsonMetadata)
+            JObject jsonMetadata,
+            HttpStatusCode statusCode,
+            Uri location)
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, $"/streams/{StreamId}")
+            var request = new HttpRequestMessage(HttpMethod.Post, $"/{Constants.Streams.Stream}/{StreamId}")
             {
                 Content = new StringContent(body.ToString())
             };
@@ -111,21 +126,25 @@
             using(var response = await _fixture.HttpClient.SendAsync(request))
             {
                 response.StatusCode.ShouldBe(statusCode);
+                response.Headers.Location.ShouldBe(location);
             }
 
             var page = await _fixture.StreamStore.ReadStreamForwards(StreamId, 0, int.MaxValue);
-            
+
             page.Status.ShouldBe(PageReadStatus.Success);
-            page.Messages.Length.ShouldBe(1);
-            page.Messages[0].MessageId.ShouldBe(messageId);
-            page.Messages[0].Type.ShouldBe("type");
-            JToken.DeepEquals(JObject.Parse(await page.Messages[0].GetJsonData()), jsonData).ShouldBeTrue();
-            JToken.DeepEquals(JObject.Parse(page.Messages[0].JsonMetadata), jsonMetadata).ShouldBeTrue();
+            page.Messages.Length.ShouldBe(messageIds.Length);
+            for(var i = 0; i < messageIds.Length; i++)
+            {
+                page.Messages[i].MessageId.ShouldBe(messageIds[i]);
+                page.Messages[i].Type.ShouldBe("type");
+                JToken.DeepEquals(JObject.Parse(await page.Messages[i].GetJsonData()), jsonData).ShouldBeTrue();
+                JToken.DeepEquals(JObject.Parse(page.Messages[i].JsonMetadata), jsonMetadata).ShouldBeTrue();
+            }
         }
 
         [Theory]
-        [InlineData(new[]{ExpectedVersion.NoStream, ExpectedVersion.NoStream})]
-        [InlineData(new[]{ExpectedVersion.NoStream, 2})]
+        [InlineData(new[] { ExpectedVersion.NoStream, ExpectedVersion.NoStream })]
+        [InlineData(new[] { ExpectedVersion.NoStream, 2 })]
         public async Task wrong_expected_version(int[] expectedVersions)
         {
             var jsonData = JObject.FromObject(new
@@ -140,11 +159,36 @@
 
             for(var i = 0; i < expectedVersions.Length - 1; i++)
             {
-                using(await _fixture.HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/streams/{StreamId}")
+                using(await _fixture.HttpClient.SendAsync(
+                    new HttpRequestMessage(HttpMethod.Post, $"/streams/{StreamId}")
+                    {
+                        Headers =
+                        {
+                            { Constants.Headers.ExpectedVersion, $"{expectedVersions[i]}" }
+                        },
+                        Content = new StringContent(JObject.FromObject(new
+                        {
+                            messageId = Guid.NewGuid(),
+                            type = "type",
+                            jsonData,
+                            jsonMetadata
+                        }).ToString())
+                        {
+                            Headers =
+                            {
+                                ContentType = new MediaTypeHeaderValue("application/json")
+                            }
+                        }
+                    }))
+                { }
+            }
+
+            using(var response = await _fixture.HttpClient.SendAsync(
+                new HttpRequestMessage(HttpMethod.Post, $"/streams/{StreamId}")
                 {
                     Headers =
                     {
-                        {Constants.Headers.ExpectedVersion, $"{expectedVersions[i]}"}
+                        { Constants.Headers.ExpectedVersion, $"{expectedVersions[expectedVersions.Length - 1]}" }
                     },
                     Content = new StringContent(JObject.FromObject(new
                     {
@@ -160,36 +204,14 @@
                         }
                     }
                 }))
-                { }
-            }
-
-            using(var response = await _fixture.HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, $"/streams/{StreamId}")
-            {
-                Headers =
-                {
-                    {Constants.Headers.ExpectedVersion, $"{expectedVersions[expectedVersions.Length - 1]}"}
-                },
-                Content = new StringContent(JObject.FromObject(new
-                {
-                    messageId = Guid.NewGuid(),
-                    type = "type",
-                    jsonData,
-                    jsonMetadata
-                }).ToString())
-                {
-                    Headers =
-                    {
-                        ContentType = new MediaTypeHeaderValue("application/json")
-                    }
-                }
-            }))
             {
                 response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
                 response.Content.Headers.ContentType.ShouldBe(new MediaTypeHeaderValue(
                     Constants.MediaTypes.HalJson));
             }
+
             var page = await _fixture.StreamStore.ReadStreamForwards(StreamId, 0, int.MaxValue);
-            
+
             page.Status.ShouldBe(PageReadStatus.Success);
             page.Messages.Length.ShouldBe(expectedVersions.Length - 1);
         }
@@ -197,9 +219,9 @@
         private static IEnumerable<string> MalformedRequests()
         {
             var messageId = Guid.NewGuid();
-            
+
             const string type = "type";
-            
+
             var jsonData = JObject.FromObject(new
             {
                 property = "value"
@@ -209,10 +231,10 @@
             {
                 property = "metaValue"
             });
-            
+
             yield return string.Empty;
             yield return "{}";
-            
+
             yield return JObject.FromObject(new
             {
                 messageId = Guid.Empty,
@@ -220,7 +242,7 @@
                 jsonData,
                 jsonMetadata
             }).ToString();
-            
+
             yield return JObject.FromObject(new
             {
                 type,

--- a/src/SqlStreamStore.HAL/Constants.cs
+++ b/src/SqlStreamStore.HAL/Constants.cs
@@ -1,6 +1,9 @@
 namespace SqlStreamStore.HAL
 {
+    using System.Linq;
+    using System.Reflection;
     using Microsoft.AspNetCore.Http;
+    using SqlStreamStore.Streams;
 
     internal static class Constants
     {
@@ -13,6 +16,13 @@ namespace SqlStreamStore.HAL
 
         public static class Headers
         {
+            public static int MinimumExpectedVersion = (from fieldInfo in typeof(ExpectedVersion)
+                    .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                where fieldInfo.IsLiteral
+                      && !fieldInfo.IsInitOnly
+                      && fieldInfo.FieldType == typeof(int)
+                select (int) fieldInfo.GetRawConstantValue()).Min();
+
             public const string ExpectedVersion = "SSS-ExpectedVersion";
             public const string HeadPosition = "SSS-HeadPosition";
             public const string Location = "Location";

--- a/src/SqlStreamStore.HAL/Streams/StreamResource.cs
+++ b/src/SqlStreamStore.HAL/Streams/StreamResource.cs
@@ -29,6 +29,16 @@ namespace SqlStreamStore.HAL.Streams
             AppendStreamOperation operation,
             CancellationToken cancellationToken)
         {
+            if(operation.ExpectedVersion < ExpectedVersion.NoStream)
+            {
+                return new HalJsonResponse(new HALResponse(new
+                {
+                    type = typeof(WrongExpectedVersionException).Name,
+                    title = "Wrong expected version.",
+                    detail = $"Expected header '{Constants.Headers.ExpectedVersion}' to have an expected version => {ExpectedVersion.NoStream}."
+                }), 400);
+            }
+            
             var result = await operation.Invoke(_streamStore, cancellationToken);
 
             var links = Links

--- a/src/SqlStreamStore.HAL/Streams/StreamResource.cs
+++ b/src/SqlStreamStore.HAL/Streams/StreamResource.cs
@@ -40,10 +40,10 @@ namespace SqlStreamStore.HAL.Streams
             var response = new HalJsonResponse(
                 new HALResponse(result)
                     .AddLinks(links),
-                result.CurrentVersion == 0
+                operation.ExpectedVersion == ExpectedVersion.NoStream
                     ? 201
                     : 200);
-            if(operation.ExpectedVersion == ExpectedVersion.NoStream)
+            if(response.StatusCode == 201)
             {
                 response.Headers[Constants.Headers.Location] =
                     new[] { $"{_relativePathToRoot}streams/{operation.StreamId}" };

--- a/src/SqlStreamStore.HAL/Streams/StreamResource.cs
+++ b/src/SqlStreamStore.HAL/Streams/StreamResource.cs
@@ -29,7 +29,7 @@ namespace SqlStreamStore.HAL.Streams
             AppendStreamOperation operation,
             CancellationToken cancellationToken)
         {
-            if(operation.ExpectedVersion < ExpectedVersion.NoStream)
+            if(operation.ExpectedVersion < Constants.Headers.MinimumExpectedVersion)
             {
                 return new HalJsonResponse(new HALResponse(new
                 {


### PR DESCRIPTION
Server would only check if `writeResult.CurrentVersion == 0` to return 201. That won't work if you write multiple messages to the stream on the first write.

At the moment it is not possible to tell if a write with ExpectedVersion.Any created the stream without doing a read first.